### PR TITLE
Bug fix - Procs returning multiple values

### DIFF
--- a/lib/cache_shoe.rb
+++ b/lib/cache_shoe.rb
@@ -23,7 +23,7 @@ module CacheShoe
   def self.get_cache_args(key_extractor, *args)
     case key_extractor
     when PASS_THROUGH then args
-    when Proc         then [key_extractor.call(*args)]
+    when Proc         then [key_extractor.call(*args)].flatten
     when Symbol       then [args.first.send(key_extractor)]
     else
       fail "Can't create a cache key from #{key_extractor.inspect}"

--- a/spec/cache_shoe_spec.rb
+++ b/spec/cache_shoe_spec.rb
@@ -112,4 +112,15 @@ RSpec.describe "when caching a service-style object" do
     When(:result) { service_ex.create thing }
     Then { service_ex.create_calls == 1 }
   end
+
+  context "when read cache takes multiple parameters" do
+    Given(:service_ex) { TwoParameterProcExample.new }
+    Given { service_ex.read thing.id, thing.name } # cache
+    When(:result) do
+      service_ex.create thing
+      service_ex.read thing.id, thing.name
+    end
+
+    Then { service_ex.read_calls == 2 }
+  end
 end

--- a/spec/support/demo_classes.rb
+++ b/spec/support/demo_classes.rb
@@ -27,6 +27,20 @@ class BaseServiceExample
   end
 end
 
+class TwoParameterProcExample < BaseServiceExample
+  include CacheShoe
+  cache_method :read, clear_on: {
+    create: lambda do |thing|
+      return thing.id, thing.name
+    end
+  }
+
+  def read(id, name)
+    @read_calls += 1
+    @storage[id]
+  end
+end
+
 class ProcServiceExample < BaseServiceExample
   include CacheShoe
   cache_method :read, clear_on: {


### PR DESCRIPTION
When caching methods that take multiple parameters, you'll have to use a proc to return the params when configuring cache clears. This fixes a bug where the cache key generated from a multiple return value situation didn't match the original cache key.
