### PR TITLE
Story/change cache key to take model

### DIFF
--- a/lib/cache_shoe.rb
+++ b/lib/cache_shoe.rb
@@ -24,14 +24,15 @@ module CacheShoe
   private
 
   module ClassMethods
-    def cache_method(method_name, model: nil, clear_on: {})
-      wrapper = CacheShoe::Wrapper.new(method_name, model, clear_on)
+    def cache_method(model, method_name)
+      wrapper = CacheShoe::Wrapper.cache(model, method_name)
       prepend wrapper.module
     end
 
-    def cache_clear(model: nil, clear_on: {})
-      wrapper = CacheShoe::Wrapper.new(nil, model, clear_on)
+    def cache_clear(model, clear_on)
+      wrapper = CacheShoe::Wrapper.clear(model, clear_on)
       prepend wrapper.module
     end
   end
 end
+

--- a/lib/cache_shoe.rb
+++ b/lib/cache_shoe.rb
@@ -24,8 +24,13 @@ module CacheShoe
   private
 
   module ClassMethods
-    def cache_method(method_name, clear_on: {})
-      wrapper = CacheShoe::Wrapper.new(method_name, clear_on)
+    def cache_method(method_name, model: nil, clear_on: {})
+      wrapper = CacheShoe::Wrapper.new(method_name, model, clear_on)
+      prepend wrapper.module
+    end
+
+    def cache_clear(model: nil, clear_on: {})
+      wrapper = CacheShoe::Wrapper.new(nil, model, clear_on)
       prepend wrapper.module
     end
   end

--- a/lib/cache_shoe/cacher.rb
+++ b/lib/cache_shoe/cacher.rb
@@ -35,9 +35,8 @@ module CacheShoe
           logger.info "Clearing cache from #{clearing_method}: #{cached_key}"
           cache.delete cached_key
         rescue => error
-          logger.error "Failed to clear cache from #{class_name}." \
-            "#{clearing_method}, because the key extractor raised " \
-            "#{error.inspect}"
+          logger.error "Failed to clear cache, because the key" \
+            " extractor raised #{error.inspect}"
         end
       end
 

--- a/lib/cache_shoe/cacher.rb
+++ b/lib/cache_shoe/cacher.rb
@@ -5,7 +5,7 @@ module CacheShoe
     def_delegators :scope,
       :args,
       :cache_key,
-      :class_name,
+      :model_class,
       :clearing_method,
       :key_extractors
 

--- a/lib/cache_shoe/scope.rb
+++ b/lib/cache_shoe/scope.rb
@@ -3,8 +3,7 @@ module CacheShoe
   # what to clear
   class Scope
     attr_reader \
-      :object,
-      :cached_method,
+      :model_class,
       :clearing_method,
       :key_extractors,
       :args,
@@ -20,8 +19,7 @@ module CacheShoe
     # any of this for free?
     def cache_key(a = args)
       [
-        class_name,
-        cached_method,
+        model_class.to_s,
         digest(a)
       ].join("::")
     end

--- a/lib/cache_shoe/scope.rb
+++ b/lib/cache_shoe/scope.rb
@@ -24,9 +24,6 @@ module CacheShoe
       ].join("::")
     end
 
-    def class_name
-      object.class.name
-    end
 
     def key_extractors
       Array(@key_extractors)

--- a/lib/cache_shoe/wrapper.rb
+++ b/lib/cache_shoe/wrapper.rb
@@ -3,20 +3,41 @@ module CacheShoe
   class Wrapper
     attr_reader :method_name, :model, :clear_on
 
-    def initialize(method_name, model, clear_on)
+    def initialize(model: nil, method_name: nil, clear_on: nil)
+      fail 'You must specify a model' if model.nil?
       @method_name = method_name
       @model = model
       @clear_on = clear_on
     end
 
+    def self.cache(model, method_name)
+      fail 'You must specify which method to cache' if method_name.nil?
+      Wrapper.new(model: model, method_name: method_name)
+    end
+
+    def self.clear(model, clear_on)
+      if !clear_on.respond_to?(:key?) || clear_on.length == 0
+        fail 'You must specify the clear_on triggers'
+      end
+      Wrapper.new(model: model, clear_on: clear_on)
+    end
+
     def module
-      wrap_the_method_to_cache if method_name
-      create_cache_clear_wrapper_methods
+      wrap_the_method_to_cache if cache?
+      create_cache_clear_wrapper_methods if clear?
 
       module_instance
     end
 
     private
+
+    def cache?
+      clear_on.nil?
+    end
+
+    def clear?
+      method_name.nil?
+    end
 
     def module_instance
       @module_instance ||= Module.new

--- a/spec/cache_shoe/scope_spec.rb
+++ b/spec/cache_shoe/scope_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe CacheShoe::Scope do
   subject(:scope) { described_class.new(options) }
 
   let(:options) {
-    { object: object, cached_method: cached_method, args: args }
+    { model_class: Object, args: args }
   }
 
-  let(:object) { Object.new }
   let(:cached_method) { :foo }
   let(:args) { ["abc"] }
 
@@ -25,15 +24,9 @@ RSpec.describe CacheShoe::Scope do
 
       it "stringifys each argument" do
         expect(cache_key).to eq(
-          'Object::foo::["first", [2, 3], true, {:fourth=>false, :fifth=>:sym}]'
+          'Object::["first", [2, 3], true, {:fourth=>false, :fifth=>:sym}]'
         )
       end
-    end
-  end
-
-  describe "#class_name" do
-    it "derives from the object" do
-      expect(scope.class_name).to eq("Object")
     end
   end
 

--- a/spec/cache_shoe_spec.rb
+++ b/spec/cache_shoe_spec.rb
@@ -1,23 +1,23 @@
-RSpec.describe "when caching a service-style object" do
+RSpec.describe 'when caching a service-style object' do
   Given { CacheShoe.config.cache.clear }
   Given(:thing) { Thing.new(123, 'name') }
 
-  shared_examples_for "caching" do
-    context "read caching" do
-      context "when nil, it should cache the nil" do
-        Given { service_ex.read("INVALID_ID") }          # cache the nil
-        When(:result) { service_ex.read("INVALID_ID") }  # now hit the cache
+  shared_examples_for 'caching' do
+    context 'read caching' do
+      context 'when nil, it should cache the nil' do
+        Given { service_ex.read('INVALID_ID') }          # cache the nil
+        When(:result) { service_ex.read('INVALID_ID') }  # now hit the cache
         Then  { service_ex.read_calls == 1 }
       end
 
-      context "when not nil, it should cache that" do
+      context 'when not nil, it should cache that' do
         Given { service_ex.create thing }
         When  { 2.times { service_ex.read(thing.id) } }
         Then  { service_ex.read_calls == 1 }
       end
     end
 
-    context "when creating it wipes the cache" do
+    context 'when creating it wipes the cache' do
       Given { service_ex.read(123) } # populate the cache with nil
       When { service_ex.create thing }
       Given(:result) { service_ex.read(123) }
@@ -25,7 +25,7 @@ RSpec.describe "when caching a service-style object" do
       And  { service_ex.read_calls == 2 }
     end
 
-    context "when deleting it wipes the cache" do
+    context 'when deleting it wipes the cache' do
       Given do
         service_ex.create thing
         # Populate the cache
@@ -42,21 +42,26 @@ RSpec.describe "when caching a service-style object" do
     end
   end
 
-  context "when using procs to clearing the cache" do
+  context 'when using procs to clearing the cache' do
     Given(:service_ex) { ProcServiceExample.new }
-    it_should_behave_like "caching"
+    it_should_behave_like 'caching'
   end
 
-  context "when using symbol keys to clear the cache" do
+  context 'when using symbol keys to clear the cache' do
     Given(:service_ex) { KeyServiceExample.new }
-    it_should_behave_like "caching"
+    it_should_behave_like 'caching'
   end
 
-  context "when caching multiple methods" do
-    Given(:service_ex) { CacheTwoMethodsExample.new }
-    it_should_behave_like "caching"
+  context 'when omitting the model class' do
+    Given(:service_ex) { DefaultModelServiceExample.new }
+    it_should_behave_like 'caching'
+  end
 
-    shared_context "create thing and cache the reads" do
+  context 'when caching multiple methods' do
+    Given(:service_ex) { CacheTwoMethodsExample.new }
+    it_should_behave_like 'caching'
+
+    shared_context 'create thing and cache the reads' do
       Given do
         service_ex.create thing
         service_ex.read 123
@@ -64,8 +69,8 @@ RSpec.describe "when caching a service-style object" do
       end
     end
 
-    context "caching works" do
-      include_context "create thing and cache the reads"
+    context 'caching works' do
+      include_context 'create thing and cache the reads'
       When(:result) do
         [service_ex.read(123), service_ex.read_hash(id: 123)]
       end
@@ -74,8 +79,8 @@ RSpec.describe "when caching a service-style object" do
       And { service_ex.read_calls == 1 }
     end
 
-    context "cache clearing works" do
-      include_context "create thing and cache the reads"
+    context 'cache clearing works' do
+      include_context 'create thing and cache the reads'
       When(:result) do
         service_ex.delete 123
         [service_ex.read(123), service_ex.read_hash(id: 123)]
@@ -87,11 +92,11 @@ RSpec.describe "when caching a service-style object" do
     end
   end
 
-  context "when clearing multiple keys" do
+  context 'when clearing multiple keys' do
     Given(:service_ex) { MultiKeyClearExample.new }
-    it_should_behave_like "caching"
+    it_should_behave_like 'caching'
 
-    context "ensure both keys are cleared" do
+    context 'ensure both keys are cleared' do
       Given do
         service_ex.read thing.id
         service_ex.read thing.name
@@ -107,13 +112,29 @@ RSpec.describe "when caching a service-style object" do
     end
   end
 
-  context "when the cache methods raise" do
+  context 'when clearing a key cached by another service' do
+    Given(:service_ex) { KeyServiceExample.new }
+    Given(:clearing_service_ex) do
+      SeparateCleaningServiceExample.new(service_ex)
+    end
+    Given do
+      service_ex.create thing
+      service_ex.read(thing.id)
+    end
+
+    When { clearing_service_ex.delete(thing.id) }
+
+    Then { service_ex.read(thing.id).nil? }
+    And  { service_ex.read_calls == 2 }
+  end
+
+  context 'when the cache methods raise' do
     Given(:service_ex) { BrokenExample.new }
     When(:result) { service_ex.create thing }
     Then { service_ex.create_calls == 1 }
   end
 
-  context "when read cache takes multiple parameters" do
+  context 'when read cache takes multiple parameters' do
     Given(:service_ex) { TwoParameterProcExample.new }
     Given { service_ex.read thing.id, thing.name } # cache
     When(:result) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,51 @@ RSpec.configure do |config|
   end
 
   config.before :each do
+    CACHE_ACTIONS.clear
     CacheShoe.config.cache.clear
+  end
+
+  CACHE_ACTIONS = {}
+
+  CacheShoe.config.on_cache = lambda do |cache_key, cache_hit|
+    CACHE_ACTIONS[cache_key] ||= []
+    CACHE_ACTIONS[cache_key] << { read: cache_hit }
+  end
+
+  CacheShoe.config.on_cache_clear = lambda do |cache_key, trigger_method|
+    CACHE_ACTIONS[cache_key] ||= []
+    CACHE_ACTIONS[cache_key] << { trigger_method => :clear }
+  end
+
+  config.after :each do |example|
+    if example.exception
+      p "-" * 30
+      p "Cache Actions"
+      pp CACHE_ACTIONS
+      p "-" * 30
+    end
   end
 end
 
+RSpec::Matchers.define :have_cached do |*expected_cache_pattern|
+  class << self
+    attr_accessor :cache_key, :actual_cache_pattern
+  end
+
+  match do |service_instance, method, *args|
+    scope = CacheShoe::Scope.new(
+      object: service_instance, cached_method: method, args: args)
+    self.cache_key = scope.cache_key
+
+    self.actual_cache_pattern =
+      (CACHE_ACTIONS[cache_key] || [{}]).flatten
+
+    actual_cache_pattern == expected_cache_pattern
+  end
+
+  failure_message_for_should do |_service_instance, _method, *_args|
+    "Expected cache pattern: #{expected_cache_pattern}, but got: " \
+      "#{actual_cache_pattern} for " \
+      "cache_key #{cache_key}"
+  end
+end

--- a/spec/support/demo_classes.rb
+++ b/spec/support/demo_classes.rb
@@ -29,7 +29,8 @@ end
 
 class TwoParameterProcExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, model: Thing, clear_on: {
+  cache_method Thing, :read
+  cache_clear  Thing, {
     create: lambda do |thing|
       return thing.id, thing.name
     end
@@ -43,21 +44,24 @@ end
 
 class ProcServiceExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, model: Thing, clear_on: {
+  cache_method Thing, :read
+  cache_clear Thing,
     create: -> (thing) { thing.id }, delete: -> (id) { id }
-  }
 end
 
 class CacheTwoMethodsExample < BaseServiceExample
   attr_accessor :read_hash_calls
   include CacheShoe
-  cache_method :read, model: Thing, clear_on: {
-    create: -> (thing) { thing.id }, delete: -> (id) { id }
-  }
+  cache_method Thing, :read
+  cache_clear  Thing,
+    create: -> (thing) { thing.id },
+    delete: -> (id) { id }
 
-  cache_method :read_hash, clear_on: {
-    create: -> (thing) { { id: thing.id } }, delete: -> (id) { { id: id } }
-  }
+
+  cache_method Thing, :read_hash
+  cache_clear  Thing,
+    create: -> (thing) { { id: thing.id } },
+    delete: -> (id) { { id: id } }
 
   def initialize
     self.read_hash_calls = 0
@@ -72,12 +76,14 @@ end
 
 class KeyServiceExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, model: Thing, clear_on: { create: :id, delete: PASS_THROUGH }
+  cache_method Thing, :read
+  cache_clear  Thing, create: :id, delete: PASS_THROUGH
 end
 
 class DefaultModelServiceExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, clear_on: { create: :id, delete: PASS_THROUGH }
+  cache_method Thing, :read
+  cache_clear  Thing, create: :id, delete: PASS_THROUGH
 end
 
 class SeparateCleaningServiceExample
@@ -85,7 +91,7 @@ class SeparateCleaningServiceExample
   def_delegators :other_service, :delete, :read_calls
   include CacheShoe
   attr_accessor :other_service
-  cache_clear model: Thing, clear_on: { delete: PASS_THROUGH }
+  cache_clear Thing, delete: PASS_THROUGH
 
   def initialize(other_service)
     self.other_service = other_service
@@ -94,10 +100,10 @@ end
 
 class MultiKeyClearExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, model: Thing, clear_on: {
+  cache_method Thing, :read
+  cache_clear  Thing,
     create: [:id, :name],
     delete: PASS_THROUGH
-  }
 
   def create(thing)
     @create_calls += 1
@@ -109,7 +115,7 @@ end
 
 class BrokenExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, model: Thing, clear_on: {
+  cache_method Thing, :read
+  cache_clear  Thing,
     create: -> (_thing) { fail 'I am broken!' }
-  }
 end

--- a/spec/support/demo_classes.rb
+++ b/spec/support/demo_classes.rb
@@ -29,7 +29,7 @@ end
 
 class TwoParameterProcExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, clear_on: {
+  cache_method :read, model: Thing, clear_on: {
     create: lambda do |thing|
       return thing.id, thing.name
     end
@@ -43,7 +43,7 @@ end
 
 class ProcServiceExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, clear_on: {
+  cache_method :read, model: Thing, clear_on: {
     create: -> (thing) { thing.id }, delete: -> (id) { id }
   }
 end
@@ -51,7 +51,7 @@ end
 class CacheTwoMethodsExample < BaseServiceExample
   attr_accessor :read_hash_calls
   include CacheShoe
-  cache_method :read, clear_on: {
+  cache_method :read, model: Thing, clear_on: {
     create: -> (thing) { thing.id }, delete: -> (id) { id }
   }
 
@@ -72,12 +72,29 @@ end
 
 class KeyServiceExample < BaseServiceExample
   include CacheShoe
+  cache_method :read, model: Thing, clear_on: { create: :id, delete: PASS_THROUGH }
+end
+
+class DefaultModelServiceExample < BaseServiceExample
+  include CacheShoe
   cache_method :read, clear_on: { create: :id, delete: PASS_THROUGH }
+end
+
+class SeparateCleaningServiceExample
+  extend Forwardable
+  def_delegators :other_service, :delete, :read_calls
+  include CacheShoe
+  attr_accessor :other_service
+  cache_clear model: Thing, clear_on: { delete: PASS_THROUGH }
+
+  def initialize(other_service)
+    self.other_service = other_service
+  end
 end
 
 class MultiKeyClearExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, clear_on: {
+  cache_method :read, model: Thing, clear_on: {
     create: [:id, :name],
     delete: PASS_THROUGH
   }
@@ -92,7 +109,7 @@ end
 
 class BrokenExample < BaseServiceExample
   include CacheShoe
-  cache_method :read, clear_on: {
+  cache_method :read, model: Thing, clear_on: {
     create: -> (_thing) { fail 'I am broken!' }
   }
 end


### PR DESCRIPTION
@justincampbell - Left this a bit ugly pending a discussion w/ you.

I added cache_clear, so that TagService could clear the account cache in AccountService. (TagService has  no method to 'cache')  Should cache_method still be able to define it's clearing methods, or should we just change the interface to:

``` ruby
cache_method :read, model: Account
cache_clear model: Account, clear_on: { ... }
```

I vote splitting them out at this point. I initially wanted them all together, but now that I've seen that they will have to be distributed across services, I've changed my mind.  It would enable putting the declarations right next to the methods they are intended to decorate, which I think would further limit confusion.

If you agree, I'll clean the code in wrapper.rb to not case based on whether the method_name is present
