### PR TITLE
Ensure that a user can not cache the same method twice

### DIFF
--- a/lib/cache_shoe.rb
+++ b/lib/cache_shoe.rb
@@ -1,7 +1,8 @@
 require 'logger'
 
-require 'cache_shoe/configuration'
 require 'cache_shoe/cacher'
+require 'cache_shoe/configuration'
+require 'cache_shoe/registry'
 require 'cache_shoe/scope'
 require 'cache_shoe/wrapper'
 
@@ -24,7 +25,8 @@ module CacheShoe
 
   module ClassMethods
     def cache_method(model, method_name)
-      assert_no_double_caching(model, method_name)
+      CacheShoe::Registry.register self, method_name
+
       wrapper = CacheShoe::Wrapper.cache(model, method_name)
       prepend wrapper.module
     end
@@ -32,17 +34,6 @@ module CacheShoe
     def cache_clear(model, clear_on)
       wrapper = CacheShoe::Wrapper.clear(model, clear_on)
       prepend wrapper.module
-    end
-
-    private
-
-    def assert_no_double_caching(model, method_name)
-      @cached_methods ||= []
-      cache_key = "#{model}::#{method_name}"
-      if @cached_methods.include?("#{cache_key}")
-        throw "You already cached #{cache_key}"
-      end
-      @cached_methods << cache_key
     end
   end
 end

--- a/lib/cache_shoe.rb
+++ b/lib/cache_shoe.rb
@@ -24,6 +24,7 @@ module CacheShoe
 
   module ClassMethods
     def cache_method(model, method_name)
+      assert_no_double_caching(model, method_name)
       wrapper = CacheShoe::Wrapper.cache(model, method_name)
       prepend wrapper.module
     end
@@ -31,6 +32,17 @@ module CacheShoe
     def cache_clear(model, clear_on)
       wrapper = CacheShoe::Wrapper.clear(model, clear_on)
       prepend wrapper.module
+    end
+
+    private
+
+    def assert_no_double_caching(model, method_name)
+      @cached_methods ||= []
+      cache_key = "#{model}::#{method_name}"
+      if @cached_methods.include?("#{cache_key}")
+        throw "You already cached #{cache_key}"
+      end
+      @cached_methods << cache_key
     end
   end
 end

--- a/lib/cache_shoe/registry.rb
+++ b/lib/cache_shoe/registry.rb
@@ -1,0 +1,25 @@
+require 'singleton'
+
+module CacheShoe
+  class Registry
+    include Singleton
+
+    def self.register(*args)
+      instance.register(*args)
+    end
+
+    def register(class_name, method_name)
+      if registry[class_name].include?(method_name)
+        fail "You already cached #{method_name} on #{class_name}"
+      end
+
+      registry[class_name] << method_name
+    end
+
+    private
+
+    def registry
+      @registry ||= Hash.new { |hash, key| hash[key] = [] }
+    end
+  end
+end

--- a/spec/cache_shoe_spec.rb
+++ b/spec/cache_shoe_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'when caching a service-style object' do
       end
     end
     Then do
-      expect(result).to have_failed(ArgumentError, /You already cached/)
+      expect(result).to have_failed(RuntimeError, /You already cached/)
     end
   end
 end

--- a/spec/cache_shoe_spec.rb
+++ b/spec/cache_shoe_spec.rb
@@ -144,4 +144,17 @@ RSpec.describe 'when caching a service-style object' do
 
     Then { service_ex.read_calls == 2 }
   end
+
+  context "when a method is cached twice for some dumb reason" do
+    When(:result) do
+      class DoubleRainbow
+        include CacheShoe
+        cache_method Object, :what_does_it_mean
+        cache_method Object, :what_does_it_mean
+      end
+    end
+    Then do
+      expect(result).to have_failed(ArgumentError, /You already cached/)
+    end
+  end
 end


### PR DESCRIPTION
If you try and cache the same method twice (an accident), things will hang and it's hard to figure out why. So this just preemptively catches that error and alerts the user.
